### PR TITLE
Add support for the API-V2 endpoint

### DIFF
--- a/SoundCloud.API.Client.Test/Internal/Client/SoundCloudRawClientTest.cs
+++ b/SoundCloud.API.Client.Test/Internal/Client/SoundCloudRawClientTest.cs
@@ -60,7 +60,7 @@ namespace SoundCloud.API.Client.Test.Internal.Client
                 uriBuilder.Expect(f => f.AddCredentials(scCredentials, scAccessToken)).Return(uriBuilder);
                 uriBuilderFactory.Expect(f => f.Create(Domain.Api.GetParameterName() + "prefix/command.json")).Return(uriBuilder);
 
-                webGateway.Expect(f => f.Request(uriBuilder, method, parameters, bytes)).Return("response");
+                webGateway.Expect(f => f.Request(uriBuilder, method, parameters, bytes, scAccessToken.AccessToken)).Return("response");
 
                 serializer.Expect(f => f.Deserialize<EmptyClass>("response")).Return(expected);
             }
@@ -86,7 +86,7 @@ namespace SoundCloud.API.Client.Test.Internal.Client
                 uriBuilder.Expect(f => f.AddCredentials(scCredentials, null)).Return(uriBuilder);
                 uriBuilderFactory.Expect(f => f.Create(Domain.Api.GetParameterName() + "prefix/command")).Return(uriBuilder);
                 
-                webGateway.Expect(f => f.Request(uriBuilder, method, parameters, null)).Return("response");
+                webGateway.Expect(f => f.Request(uriBuilder, method, parameters, null, "")).Return("response");
             }
 
             var soundCloudRawClient = new SoundCloudRawClient(scCredentials, uriBuilderFactory, webGateway, serializer)

--- a/SoundCloud.API.Client.Test/SoundCloud.API.Client.Test.csproj
+++ b/SoundCloud.API.Client.Test/SoundCloud.API.Client.Test.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Subresources\AppApiTest.cs" />
     <Compile Include="Subresources\CommentApiTest.cs" />
+    <Compile Include="Subresources\ExploreApiTest.cs" />
     <Compile Include="Subresources\GroupApiTest.cs" />
     <Compile Include="Subresources\MeApiTest.cs" />
     <Compile Include="Subresources\OEmbedApiTest.cs" />

--- a/SoundCloud.API.Client.Test/SoundCloud.API.Client.Test.csproj
+++ b/SoundCloud.API.Client.Test/SoundCloud.API.Client.Test.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Internal\Converters\TagListConverterTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Subresources\AppApiTest.cs" />
+    <Compile Include="Subresources\ChartApiTest.cs" />
     <Compile Include="Subresources\CommentApiTest.cs" />
     <Compile Include="Subresources\ExploreApiTest.cs" />
     <Compile Include="Subresources\GroupApiTest.cs" />
@@ -95,6 +96,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SoundCloud.API.Client.Test/SoundCloud.API.Client.Test.csproj
+++ b/SoundCloud.API.Client.Test/SoundCloud.API.Client.Test.csproj
@@ -38,9 +38,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Assemblies\TestingTools\Castle.DynamicProxy2.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SoundCloud.API.Client.Test/Subresources/ChartApiTest.cs
+++ b/SoundCloud.API.Client.Test/Subresources/ChartApiTest.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using SoundCloud.API.Client.Subresources;
+using System;
+
+namespace SoundCloud.API.Client.Test.Subresources
+{
+    public class ChartApiTest : AuthTestBase
+    {
+        private IChartApi chartApi;
+        private IExploreApi exploreApi;
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            exploreApi = soundCloudClient.Explore;
+            chartApi = soundCloudClient.Chart;
+        }
+
+        [Test]
+        public void TestGetChartAllSongs()
+        {
+            var tracks = chartApi.GetTracks(null);
+            Assert.IsTrue(tracks.Count() > 0);
+        }
+
+        [Test]
+        public void TestGetChartSpecificCategory()
+        {
+            var categories = exploreApi.GetExploreCategories();
+            var tracks = chartApi.GetTracks(categories[1]);
+            Assert.IsTrue(tracks.Count() > 0);
+        }
+
+        [Test]
+        public void TestGetChartPopularMusicCategory()
+        {
+            var categories = exploreApi.GetExploreCategories();
+            var tracks = chartApi.GetTracks(categories.First());
+            Assert.IsTrue(tracks.Count() > 0);
+        }
+    }
+}

--- a/SoundCloud.API.Client.Test/Subresources/ChartApiTest.cs
+++ b/SoundCloud.API.Client.Test/Subresources/ChartApiTest.cs
@@ -40,5 +40,14 @@ namespace SoundCloud.API.Client.Test.Subresources
             var tracks = chartApi.GetTracks(categories.First());
             Assert.IsTrue(tracks.Count() > 0);
         }
+
+        [Test]
+        public void TestDubstepCategory()
+        {
+            var categories = exploreApi.GetExploreCategories();
+            var tracks = chartApi.GetTracks(categories.First(ec => ec.Name == "Dubstep"));
+            Assert.IsTrue(tracks.Count() > 0);
+        }
+
     }
 }

--- a/SoundCloud.API.Client.Test/Subresources/ExploreApiTest.cs
+++ b/SoundCloud.API.Client.Test/Subresources/ExploreApiTest.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using SoundCloud.API.Client.Subresources;
+using System;
+
+namespace SoundCloud.API.Client.Test.Subresources
+{
+    public class ExploreApiTest : AuthTestBase
+    {
+        private IExploreApi exploreApi;
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            exploreApi = soundCloudClient.Explore;
+        }
+
+        [Test]
+        public void TestGetExploreCategories()
+        {
+            var categories = exploreApi.GetExploreCategories();
+            Assert.IsTrue(categories.Count() > 0);
+            Assert.IsTrue(categories.Any(c => c.Name.Contains("Rock")));
+        }
+
+        [Test]
+        public void TestGetTracks()
+        {
+            var tracks = exploreApi.GetTracks(exploreApi.GetExploreCategories().First());
+            Assert.IsTrue(tracks.Count() > 0);
+        }
+
+    }
+}

--- a/SoundCloud.API.Client.Test/Subresources/TracksApiTest.cs
+++ b/SoundCloud.API.Client.Test/Subresources/TracksApiTest.cs
@@ -73,7 +73,7 @@ namespace SoundCloud.API.Client.Test.Subresources
         public void TestSearchByTags()
         {
             var tracks = tracksSearcher().Tags("folk", "indie").Exec();
-            var invalidTracks = tracks.Where(x => !(x.TagList.Tags.Select(y => y.ToLower()).Contains("indie") || x.TagList.Tags.Select(y => y.ToLower()).Contains("folk"))).ToArray();
+            var invalidTracks = tracks.Where(x => !(x.TagList.Tags.Select(y => (y.ToLowerInvariant().Contains("indie") || y.ToLowerInvariant().Contains("folk"))).Any(b => b))).ToArray();
             Assert.AreEqual(0, invalidTracks.Length);
         }
 

--- a/SoundCloud.API.Client.Test/Subresources/TracksApiTest.cs
+++ b/SoundCloud.API.Client.Test/Subresources/TracksApiTest.cs
@@ -18,7 +18,7 @@ namespace SoundCloud.API.Client.Test.Subresources
             base.TestFixtureSetUp();
 
             tracksApi = soundCloudClient.Tracks;
-            tracksSearcher = () => tracksApi.BeginSearch(SCFilter.All);
+            tracksSearcher = () => tracksApi.BeginSearch(SCFilter.All, false);
         }
 
         [Test]
@@ -26,20 +26,20 @@ namespace SoundCloud.API.Client.Test.Subresources
         [TestCase(SCFilter.Public)]
         public void TestSearchByFilter(SCFilter filter)
         {
-            TestCollection((o,c) =>tracksApi.BeginSearch(filter).Exec(SCOrder.CreatedAt, o, c), 0 ,50);
+            TestCollection((o,c) =>tracksApi.BeginSearch(filter, false).Exec(SCOrder.CreatedAt, o, c), 0 ,50);
         }
 
         [Test]
         public void TestSearchDownloadable()
         {
-            var tracks = tracksApi.BeginSearch(SCFilter.Downloadable).Exec();
+            var tracks = tracksApi.BeginSearch(SCFilter.Downloadable, false).Exec();
             Assert.IsTrue(tracks.All(x => x.Downloadable.HasValue && x.Downloadable.Value));
         }
 
         [Test]
         public void TestSearchStreamable()
         {
-            var tracks = tracksApi.BeginSearch(SCFilter.Streamable).Exec();
+            var tracks = tracksApi.BeginSearch(SCFilter.Streamable, false).Exec();
             Assert.IsTrue(tracks.All(x => x.Streamable.HasValue && x.Streamable.Value));
         }
 
@@ -171,6 +171,13 @@ namespace SoundCloud.API.Client.Test.Subresources
         public void TestSearchByTypes()
         {
             TestCollection((o, c) => tracksSearcher().Types(SCTrackType.Podcast, SCTrackType.Recording).Exec(SCOrder.CreatedAt, o, c), 0, 50);
+        }
+
+        [Test]
+        public void TestNewSeachApi()
+        {
+            var tracks = tracksApi.BeginSearch(SCFilter.All, true).Query("Boat That's Capsized").Exec();
+            Assert.IsTrue(tracks.Any(x => x.Title.Contains("Boat That's Capsized")));
         }
     }
 }

--- a/SoundCloud.API.Client.Test/packages.config
+++ b/SoundCloud.API.Client.Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/SoundCloud.API.Client.Web/SoundCloud.API.Client.Web.csproj
+++ b/SoundCloud.API.Client.Web/SoundCloud.API.Client.Web.csproj
@@ -40,9 +40,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/SoundCloud.API.Client.Web/packages.config
+++ b/SoundCloud.API.Client.Web/packages.config
@@ -10,5 +10,5 @@
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
 </packages>

--- a/SoundCloud.API.Client/Factories/SubresourceFactoryBuilder.cs
+++ b/SoundCloud.API.Client/Factories/SubresourceFactoryBuilder.cs
@@ -18,6 +18,7 @@ namespace SoundCloud.API.Client.Factories
         private readonly IWebProfileConverter webProfileConverter;
         private readonly IConnectionConverter connectionConverter;
         private readonly IActivityResultConverter activityResultConverter;
+        private readonly IExploreCategoryConverter exploreCategoryConverter;
 
         public SubresourceFactoryBuilder()
         {
@@ -34,6 +35,7 @@ namespace SoundCloud.API.Client.Factories
             webProfileConverter = new WebProfileConverter(dateTimeConverter);
             connectionConverter = new ConnectionConverter(dateTimeConverter);
             activityResultConverter = new ActivityResultConverter(trackConverter, commentConverter, userConverter, playlistConverter, dateTimeConverter);
+            exploreCategoryConverter = new ExploreCategoryConverter();
         }
 
         public ISubresourceFactory CreateSubresourceFactory(ISoundCloudRawClient soundCloudRawClient)
@@ -49,7 +51,8 @@ namespace SoundCloud.API.Client.Factories
                 webProfileConverter, 
                 connectionConverter, 
                 activityResultConverter, 
-                applicationConverter);
+                applicationConverter,
+                exploreCategoryConverter);
         }
     }
 }

--- a/SoundCloud.API.Client/ISoundCloudClient.cs
+++ b/SoundCloud.API.Client/ISoundCloudClient.cs
@@ -26,6 +26,8 @@ namespace SoundCloud.API.Client
 
         IResolveApi Resolve { get; }
 
+        IExploreApi Explore { get; }
+
         IOEmbed OEmbed { get; }
     }
 }

--- a/SoundCloud.API.Client/ISoundCloudClient.cs
+++ b/SoundCloud.API.Client/ISoundCloudClient.cs
@@ -28,6 +28,8 @@ namespace SoundCloud.API.Client
 
         IExploreApi Explore { get; }
 
+        IChartApi Chart { get; }
+
         IOEmbed OEmbed { get; }
     }
 }

--- a/SoundCloud.API.Client/IUnauthorizedSoundCloudClient.cs
+++ b/SoundCloud.API.Client/IUnauthorizedSoundCloudClient.cs
@@ -24,6 +24,8 @@ namespace SoundCloud.API.Client
 
         IExploreApi Explore { get; }
 
+        IChartApi Chart { get; }
+
         IOEmbed OEmbed { get; } 
     }
 }

--- a/SoundCloud.API.Client/IUnauthorizedSoundCloudClient.cs
+++ b/SoundCloud.API.Client/IUnauthorizedSoundCloudClient.cs
@@ -22,6 +22,8 @@ namespace SoundCloud.API.Client
 
         IResolveApi Resolve { get; }
 
+        IExploreApi Explore { get; }
+
         IOEmbed OEmbed { get; } 
     }
 }

--- a/SoundCloud.API.Client/Internal/Client/Helpers/Domain.cs
+++ b/SoundCloud.API.Client/Internal/Client/Helpers/Domain.cs
@@ -8,6 +8,9 @@ namespace SoundCloud.API.Client.Internal.Client.Helpers
         Api,
 
         [Parameter("https://soundcloud.com/")]
-        Direct
+        Direct,
+
+        [Parameter("https://api-v2.soundcloud.com/")]
+        ApiV2
     }
 }

--- a/SoundCloud.API.Client/Internal/Client/SoundCloudRawClient.cs
+++ b/SoundCloud.API.Client/Internal/Client/SoundCloudRawClient.cs
@@ -55,14 +55,18 @@ namespace SoundCloud.API.Client.Internal.Client
 
         public Stream RequestStream(string apiPrefix, string command, HttpMethod method, Dictionary<string, object> parameters = null, byte[] body = null, Domain domain = Domain.Api)
         {
+            string token = "";
+            if (AccessToken != null) token = AccessToken.AccessToken;
             var uriBuilder = CreateUriBuilder(domain, apiPrefix, command, string.Empty);
-            return webGateway.RequestStream(uriBuilder, method, parameters, body);
+            return webGateway.RequestStream(uriBuilder, method, parameters, body, token);
         }
 
         private string GetResponse(Domain domain, string prefix, string command, HttpMethod method, Dictionary<string, object> parameters, byte[] body, string responseType)
         {
+            string token = "";
+            if (AccessToken != null) token = AccessToken.AccessToken;
             var uriBuilder = CreateUriBuilder(domain, prefix, command, responseType);
-            var response = webGateway.Request(uriBuilder, method, parameters, body);
+            var response = webGateway.Request(uriBuilder, method, parameters, body, token);
             return response;
         }
 

--- a/SoundCloud.API.Client/Internal/Converters/ExploreCategoryConverter.cs
+++ b/SoundCloud.API.Client/Internal/Converters/ExploreCategoryConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using SoundCloud.API.Client.Internal.Objects;
+using SoundCloud.API.Client.Objects;
+using System.Linq;
+
+namespace SoundCloud.API.Client.Internal.Converters
+{
+    internal class ExploreCategoryConverter : IExploreCategoryConverter
+    {
+        public SCExploreCategory[] Convert(ExploreCategoryList categoryList)
+        {
+            if (categoryList == null)
+            {
+                return null;
+            }
+
+            return categoryList.MusicCategoryNames.Select(cn => new SCExploreCategory { Name = cn }).ToArray();
+        }
+    }
+}

--- a/SoundCloud.API.Client/Internal/Converters/IExploreCategoryConverter.cs
+++ b/SoundCloud.API.Client/Internal/Converters/IExploreCategoryConverter.cs
@@ -1,0 +1,10 @@
+﻿using SoundCloud.API.Client.Internal.Objects;
+using SoundCloud.API.Client.Objects;
+
+namespace SoundCloud.API.Client.Internal.Converters
+{
+    internal interface IExploreCategoryConverter
+    {
+        SCExploreCategory[] Convert(ExploreCategoryList categoryList);
+    }
+}

--- a/SoundCloud.API.Client/Internal/Converters/Infrastructure/TagListConverter.cs
+++ b/SoundCloud.API.Client/Internal/Converters/Infrastructure/TagListConverter.cs
@@ -67,24 +67,24 @@ namespace SoundCloud.API.Client.Internal.Converters.Infrastructure
 
         private static IEnumerable<string> ParseTags(string tagList)
         {
-            if (tagList.Contains("\n"))
-            {
-                //invalid tags goes here
-                //sample:
-                //
-                //Studio
-                //Tag: Music
-                //Tag: Mix
-                //Tag: Word
-                //Tag: Folk
-                //Tag: Sanharib Assure
-                //Tag: assyrian
-                //Add tags
-                //
-                //it's whole string with \n
+            //if (tagList.Contains("\n"))
+            //{
+            //    //invalid tags goes here
+            //    //sample:
+            //    //
+            //    //Studio
+            //    //Tag: Music
+            //    //Tag: Mix
+            //    //Tag: Word
+            //    //Tag: Folk
+            //    //Tag: Sanharib Assure
+            //    //Tag: assyrian
+            //    //Add tags
+            //    //
+            //    //it's whole string with \n
 
-                return new[] {tagList};
-            }
+            //    return new[] {tagList};
+            //}
 
             var chars = tagList.ToCharArray();
             var separatorMode = true;

--- a/SoundCloud.API.Client/Internal/Infrastructure/Network/IWebGateway.cs
+++ b/SoundCloud.API.Client/Internal/Infrastructure/Network/IWebGateway.cs
@@ -8,8 +8,8 @@ namespace SoundCloud.API.Client.Internal.Infrastructure.Network
 {
     internal interface IWebGateway
     {
-        string Request(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body);
-        Stream RequestStream(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body);
+        string Request(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body, string accessToken);
+        Stream RequestStream(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body, string accessToken);
         string Upload(IUriBuilder uriBuilder, Dictionary<string, object> parameters, params File[] files);
     }
 }

--- a/SoundCloud.API.Client/Internal/Infrastructure/Network/WebGateway.cs
+++ b/SoundCloud.API.Client/Internal/Infrastructure/Network/WebGateway.cs
@@ -14,18 +14,18 @@ namespace SoundCloud.API.Client.Internal.Infrastructure.Network
 {
     internal class WebGateway : IWebGateway
     {
-        public string Request(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body)
+        public string Request(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body, string accessToken)
         {
             Func<int, string, string> buildExceptionMessage;
-            var request = BuildRequest(uriBuilder, method, parameters, body, out buildExceptionMessage);
+            var request = BuildRequest(uriBuilder, method, parameters, body, accessToken, out buildExceptionMessage);
 
             return GetContent(request, buildExceptionMessage);
         }
 
-        public Stream RequestStream(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body)
+        public Stream RequestStream(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body, string accessToken)
         {
             Func<int, string, string> buildExceptionMessage;
-            var request = BuildRequest(uriBuilder, method, parameters, body, out buildExceptionMessage);
+            var request = BuildRequest(uriBuilder, method, parameters, body, accessToken, out buildExceptionMessage);
 
             var response = GetResponse(request, (statusCode, content) => string.Format("RequestStream exception. Parameters: method = {1}, uri = {0}. Response: {2} - {3}.", uriBuilder.Build(), method, statusCode, content));
             return response.GetResponseStream();
@@ -117,7 +117,7 @@ namespace SoundCloud.API.Client.Internal.Infrastructure.Network
             }
         }
 
-        private static WebRequest BuildRequest(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body, out Func<int, string, string> buildExceptionMessage)
+        private static WebRequest BuildRequest(IUriBuilder uriBuilder, HttpMethod method, Dictionary<string, object> parameters, byte[] body, string acessToken, out Func<int, string, string> buildExceptionMessage)
         {
             var uri = uriBuilder.AddQueryParameters(parameters).Build();
             var request = WebRequest.Create(uri);
@@ -142,6 +142,7 @@ namespace SoundCloud.API.Client.Internal.Infrastructure.Network
             }
 
             request.Headers.Add(HttpRequestHeader.AcceptEncoding, "gzip, deflate");
+            request.Headers.Add("Authorization", "OAuth " + acessToken);
 
             buildExceptionMessage = (statusCode, content) =>
                 string.Format("WebRequest exception. Parameters: method = {1}, uri = {0}. Response: {2} - {3}.", uri.AbsoluteUri, method, statusCode, content);

--- a/SoundCloud.API.Client/Internal/Infrastructure/Serialization/Custom/JsonCreationConverter.cs
+++ b/SoundCloud.API.Client/Internal/Infrastructure/Serialization/Custom/JsonCreationConverter.cs
@@ -15,6 +15,8 @@ namespace SoundCloud.API.Client.Internal.Infrastructure.Serialization.Custom
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
         {
+            serializer.NullValueHandling = NullValueHandling.Ignore;
+            serializer.DefaultValueHandling = DefaultValueHandling.Populate;
             var jsonObject = JObject.Load(reader);
 
             var target = Create(objectType, jsonObject);

--- a/SoundCloud.API.Client/Internal/Infrastructure/Serialization/JsonSerializer.cs
+++ b/SoundCloud.API.Client/Internal/Infrastructure/Serialization/JsonSerializer.cs
@@ -14,7 +14,14 @@ namespace SoundCloud.API.Client.Internal.Infrastructure.Serialization
 
         public T Deserialize<T>(string json)
         {
-            return JsonConvert.DeserializeObject<T>(json, customConverters);
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(json, customConverters);
+            }
+            catch (System.Exception ex)
+            {
+                throw;
+            }
         }
     }
 }

--- a/SoundCloud.API.Client/Internal/Objects/Activities/ActivityBase.cs
+++ b/SoundCloud.API.Client/Internal/Objects/Activities/ActivityBase.cs
@@ -4,13 +4,13 @@ namespace SoundCloud.API.Client.Internal.Objects.Activities
 {
     internal abstract class ActivityBase
     {
-        [JsonProperty(PropertyName = "type")]
+        [JsonProperty(PropertyName = "type", NullValueHandling = NullValueHandling.Ignore)]
         public string Type { get; set; }
 
-        [JsonProperty(PropertyName = "created_at")]
+        [JsonProperty(PropertyName = "created_at", NullValueHandling = NullValueHandling.Ignore)]
         public string CreatedAt { get; set; }
 
-        [JsonProperty(PropertyName = "tags")]
+        [JsonProperty(PropertyName = "tags", NullValueHandling = NullValueHandling.Ignore)]
         public string Tags { get; set; }
     }
 }

--- a/SoundCloud.API.Client/Internal/Objects/Activities/ActivityComment.cs
+++ b/SoundCloud.API.Client/Internal/Objects/Activities/ActivityComment.cs
@@ -4,7 +4,7 @@ namespace SoundCloud.API.Client.Internal.Objects.Activities
 {
     internal class ActivityComment : ActivityBase, IActivity<Comment>
     {
-        [JsonProperty(PropertyName = "origin")]
+        [JsonProperty(PropertyName = "origin", NullValueHandling = NullValueHandling.Ignore)]
         public Comment Origin { get; set; }
     }
 }

--- a/SoundCloud.API.Client/Internal/Objects/Activities/ActivityFavoriting.cs
+++ b/SoundCloud.API.Client/Internal/Objects/Activities/ActivityFavoriting.cs
@@ -4,7 +4,7 @@ namespace SoundCloud.API.Client.Internal.Objects.Activities
 {
     internal class ActivityFavoriting : ActivityBase, IActivity<User>
     {
-        [JsonProperty(PropertyName = "origin")]
+        [JsonProperty(PropertyName = "origin", NullValueHandling = NullValueHandling.Ignore)]
         public User Origin { get; set; }
     }
 }

--- a/SoundCloud.API.Client/Internal/Objects/Activities/ActivityPlaylist.cs
+++ b/SoundCloud.API.Client/Internal/Objects/Activities/ActivityPlaylist.cs
@@ -4,7 +4,7 @@ namespace SoundCloud.API.Client.Internal.Objects.Activities
 {
     internal class ActivityPlaylist : ActivityBase, IActivity<Playlist>
     {
-        [JsonProperty(PropertyName = "origin")]
+        [JsonProperty(PropertyName = "origin", NullValueHandling = NullValueHandling.Ignore)]
         public Playlist Origin { get; set; }
     }
 }

--- a/SoundCloud.API.Client/Internal/Objects/ChartTrack.cs
+++ b/SoundCloud.API.Client/Internal/Objects/ChartTrack.cs
@@ -6,7 +6,7 @@ namespace SoundCloud.API.Client.Internal.Objects
 {
     internal class ChartTrack
     {
-        [JsonProperty(PropertyName = "track")]
+        [JsonProperty(PropertyName = "track", NullValueHandling = NullValueHandling.Ignore)]
         public Track Track { get; set; }
 
     }

--- a/SoundCloud.API.Client/Internal/Objects/ChartTrack.cs
+++ b/SoundCloud.API.Client/Internal/Objects/ChartTrack.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using SoundCloud.API.Client.Objects;
+using System.Collections.Generic;
+
+namespace SoundCloud.API.Client.Internal.Objects
+{
+    internal class ChartTrack
+    {
+        [JsonProperty(PropertyName = "track")]
+        public Track Track { get; set; }
+
+    }
+}

--- a/SoundCloud.API.Client/Internal/Objects/ChartTrackList.cs
+++ b/SoundCloud.API.Client/Internal/Objects/ChartTrackList.cs
@@ -6,7 +6,7 @@ namespace SoundCloud.API.Client.Internal.Objects
 {
     internal class ChartTrackList
     {
-        [JsonProperty(PropertyName = "collection")]
+        [JsonProperty(PropertyName = "collection", NullValueHandling = NullValueHandling.Ignore)]
         public List<ChartTrack> Tracks { get; set; }
     }
 }

--- a/SoundCloud.API.Client/Internal/Objects/ChartTrackList.cs
+++ b/SoundCloud.API.Client/Internal/Objects/ChartTrackList.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using SoundCloud.API.Client.Objects;
+using System.Collections.Generic;
+
+namespace SoundCloud.API.Client.Internal.Objects
+{
+    internal class ChartTrackList
+    {
+        [JsonProperty(PropertyName = "collection")]
+        public List<ChartTrack> Tracks { get; set; }
+    }
+}

--- a/SoundCloud.API.Client/Internal/Objects/ExploreCategoryList.cs
+++ b/SoundCloud.API.Client/Internal/Objects/ExploreCategoryList.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using SoundCloud.API.Client.Objects;
+using System.Collections.Generic;
+
+namespace SoundCloud.API.Client.Internal.Objects
+{
+    internal class ExploreCategoryList
+    {
+        [JsonProperty(PropertyName = "music")]
+        public List<string> MusicCategoryNames { get; set; }
+
+        [JsonProperty(PropertyName = "audio")]
+        public List<string> AudioCategoryNames { get; set; }
+    }
+}

--- a/SoundCloud.API.Client/Internal/Objects/ExploreTrackList.cs
+++ b/SoundCloud.API.Client/Internal/Objects/ExploreTrackList.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using SoundCloud.API.Client.Objects;
+using System.Collections.Generic;
+
+namespace SoundCloud.API.Client.Internal.Objects
+{
+    internal class ExploreTrackList
+    {
+        [JsonProperty(PropertyName = "tracks")]
+        public List<Track> Tracks { get; set; }
+    }
+}

--- a/SoundCloud.API.Client/Internal/Objects/ExploreTrackList.cs
+++ b/SoundCloud.API.Client/Internal/Objects/ExploreTrackList.cs
@@ -6,7 +6,7 @@ namespace SoundCloud.API.Client.Internal.Objects
 {
     internal class ExploreTrackList
     {
-        [JsonProperty(PropertyName = "tracks")]
+        [JsonProperty(PropertyName = "tracks", NullValueHandling = NullValueHandling.Ignore)]
         public List<Track> Tracks { get; set; }
     }
 }

--- a/SoundCloud.API.Client/Internal/Objects/Track.cs
+++ b/SoundCloud.API.Client/Internal/Objects/Track.cs
@@ -139,7 +139,7 @@ namespace SoundCloud.API.Client.Internal.Objects
         [JsonProperty(PropertyName = "favoritings_count")]
         public int FavoritingsCount { get; set; }
 
-        [JsonProperty(PropertyName = "comment_count")]
+        [JsonProperty(PropertyName = "comment_count", NullValueHandling = NullValueHandling.Ignore)]
         public int CommentsCount { get; set; }
 
         [JsonProperty(PropertyName = "attachments_uri")]

--- a/SoundCloud.API.Client/Internal/Objects/Track.cs
+++ b/SoundCloud.API.Client/Internal/Objects/Track.cs
@@ -1,154 +1,155 @@
 ﻿using Newtonsoft.Json;
+using System.ComponentModel;
 
 namespace SoundCloud.API.Client.Internal.Objects
 {
     internal class Track
     {
-        [JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id", NullValueHandling = NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [JsonProperty(PropertyName = "created_at")]
+        [JsonProperty(PropertyName = "created_at", NullValueHandling = NullValueHandling.Ignore)]
         public string CreatedAt { get; set; }
 
-        [JsonProperty(PropertyName = "user_id")]
+        [JsonProperty(PropertyName = "user_id", NullValueHandling = NullValueHandling.Ignore)]
         public string UserId { get; set; }
 
-        [JsonProperty(PropertyName = "duration")]
+        [JsonProperty(PropertyName = "duration", NullValueHandling = NullValueHandling.Ignore)]
         public int Duration { get; set; }
 
-        [JsonProperty(PropertyName = "commentable")]
+        [JsonProperty(PropertyName = "commentable", NullValueHandling = NullValueHandling.Ignore)]
         public bool Commentable { get; set; }
 
-        [JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state", NullValueHandling = NullValueHandling.Ignore)]
         public string State { get; set; }
 
-        [JsonProperty(PropertyName = "sharing")]
+        [JsonProperty(PropertyName = "sharing", NullValueHandling = NullValueHandling.Ignore)]
         public string Sharing { get; set; }
 
-        [JsonProperty(PropertyName = "embeddable_by")]
+        [JsonProperty(PropertyName = "embeddable_by", NullValueHandling = NullValueHandling.Ignore)]
         public string EmbeddableBy { get; set; }
 
-        [JsonProperty(PropertyName = "tag_list")]
+        [JsonProperty(PropertyName = "tag_list", NullValueHandling = NullValueHandling.Ignore)]
         public string TagList { get; set; }
 
-        [JsonProperty(PropertyName = "permalink")]
+        [JsonProperty(PropertyName = "permalink", NullValueHandling = NullValueHandling.Ignore)]
         public string Permalink { get; set; }
 
-        [JsonProperty(PropertyName = "description")]
+        [JsonProperty(PropertyName = "description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
 
-        [JsonProperty(PropertyName = "streamable")]
+        [JsonProperty(PropertyName = "streamable", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Streamable { get; set; }
 
-        [JsonProperty(PropertyName = "downloadable")]
+        [JsonProperty(PropertyName = "downloadable", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Downloadable { get; set; }
 
-        [JsonProperty(PropertyName = "genre")]
+        [JsonProperty(PropertyName = "genre", NullValueHandling = NullValueHandling.Ignore)]
         public string Genre { get; set; }
 
-        [JsonProperty(PropertyName = "release")]
+        [JsonProperty(PropertyName = "release", NullValueHandling = NullValueHandling.Ignore)]
         public string Release { get; set; }
 
-        [JsonProperty(PropertyName = "purchase_url")]
+        [JsonProperty(PropertyName = "purchase_url", NullValueHandling = NullValueHandling.Ignore)]
         public string PurchaseUrl { get; set; }
 
-        [JsonProperty(PropertyName = "label")] 
+        [JsonProperty(PropertyName = "label", NullValueHandling = NullValueHandling.Ignore)] 
         public User Label { get; set; }
 
-        [JsonProperty(PropertyName = "label_id")]
+        [JsonProperty(PropertyName = "label_id", NullValueHandling = NullValueHandling.Ignore)]
         public string LabelId { get; set; }
 
-        [JsonProperty(PropertyName = "label_name")]
+        [JsonProperty(PropertyName = "label_name", NullValueHandling = NullValueHandling.Ignore)]
         public string LabelName { get; set; }
 
-        [JsonProperty(PropertyName = "isrc")]
+        [JsonProperty(PropertyName = "isrc", NullValueHandling = NullValueHandling.Ignore)]
         public string Isrc { get; set; }
 
-        [JsonProperty(PropertyName = "video_url")]
+        [JsonProperty(PropertyName = "video_url", NullValueHandling = NullValueHandling.Ignore)]
         public string VideoUrl { get; set; }
 
-        [JsonProperty(PropertyName = "track_type")]
+        [JsonProperty(PropertyName = "track_type", NullValueHandling = NullValueHandling.Ignore)]
         public string TrackType { get; set; }
 
-        [JsonProperty(PropertyName = "key_signature")]
+        [JsonProperty(PropertyName = "key_signature", NullValueHandling = NullValueHandling.Ignore)]
         public string KeySignature { get; set; }
 
-        [JsonProperty(PropertyName = "bpm")]
+        [JsonProperty(PropertyName = "bpm", NullValueHandling = NullValueHandling.Ignore)]
         public float? Bpm { get; set; }
 
-        [JsonProperty(PropertyName = "title")]
+        [JsonProperty(PropertyName = "title", NullValueHandling = NullValueHandling.Ignore)]
         public string Title { get; set; }
 
-        [JsonProperty(PropertyName = "release_year")]
+        [JsonProperty(PropertyName = "release_year", NullValueHandling = NullValueHandling.Ignore)]
         public int? ReleaseYear { get; set; }
 
-        [JsonProperty(PropertyName = "release_month")]
+        [JsonProperty(PropertyName = "release_month", NullValueHandling = NullValueHandling.Ignore)]
         public int? ReleaseMonth { get; set; }
 
-        [JsonProperty(PropertyName = "release_day")]
+        [JsonProperty(PropertyName = "release_day", NullValueHandling = NullValueHandling.Ignore)]
         public int? ReleaseDay { get; set; }
 
-        [JsonProperty(PropertyName = "original_format")]
+        [JsonProperty(PropertyName = "original_format", NullValueHandling = NullValueHandling.Ignore)]
         public string OriginalFormat { get; set; }
 
-        [JsonProperty(PropertyName = "license")]
+        [JsonProperty(PropertyName = "license", NullValueHandling = NullValueHandling.Ignore)]
         public string License { get; set; }
 
-        [JsonProperty(PropertyName = "uri")]
+        [JsonProperty(PropertyName = "uri", NullValueHandling = NullValueHandling.Ignore)]
         public string Uri { get; set; }
 
-        [JsonProperty(PropertyName = "permalink_url")]
+        [JsonProperty(PropertyName = "permalink_url", NullValueHandling = NullValueHandling.Ignore)]
         public string PermalinkUrl { get; set; }
 
-        [JsonProperty(PropertyName = "artwork_url")]
+        [JsonProperty(PropertyName = "artwork_url", NullValueHandling = NullValueHandling.Ignore)]
         public string Artwork { get; set; }
 
-        [JsonProperty(PropertyName = "waveform_url")]
+        [JsonProperty(PropertyName = "waveform_url", NullValueHandling = NullValueHandling.Ignore)]
         public string WaveformUrl { get; set; }
 
-        [JsonProperty(PropertyName = "user")]
+        [JsonProperty(PropertyName = "user", NullValueHandling = NullValueHandling.Ignore)]
         public User User { get; set; }
 
-        [JsonProperty(PropertyName = "stream_url")]
+        [JsonProperty(PropertyName = "stream_url", NullValueHandling = NullValueHandling.Ignore)]
         public string StreamUrl { get; set; }
 
-        [JsonProperty(PropertyName = "download_url")]
+        [JsonProperty(PropertyName = "download_url", NullValueHandling = NullValueHandling.Ignore)]
         public string DownloadUrl { get; set; }
 
-        [JsonProperty(PropertyName = "downloads_remaining")]
+        [JsonProperty(PropertyName = "downloads_remaining", NullValueHandling = NullValueHandling.Ignore)]
         public int? DownloadsRemaining { get; set; }
 
-        [JsonProperty(PropertyName = "secret_token")]
+        [JsonProperty(PropertyName = "secret_token", NullValueHandling = NullValueHandling.Ignore)]
         public string SecretToken { get; set; }
 
-        [JsonProperty(PropertyName = "secret_uri")]
+        [JsonProperty(PropertyName = "secret_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string SecretUri { get; set; }
 
-        [JsonProperty(PropertyName = "user_playback_count")]
+        [JsonProperty(PropertyName = "user_playback_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? UserPlaybackCount { get; set; }
 
-        [JsonProperty(PropertyName = "user_favorite")]
+        [JsonProperty(PropertyName = "user_favorite", NullValueHandling = NullValueHandling.Ignore)]
         public bool? UserFavorite { get; set; }
 
-        [JsonProperty(PropertyName = "playback_count")]
+        [JsonProperty(PropertyName = "playback_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? PlaybackCount { get; set; }
 
-        [JsonProperty(PropertyName = "download_count")]
+        [JsonProperty(PropertyName = "download_count", NullValueHandling = NullValueHandling.Ignore), DefaultValue(0)]
         public int DownloadCount { get; set; }
 
-        [JsonProperty(PropertyName = "favoritings_count")]
+        [JsonProperty(PropertyName = "favoritings_count", NullValueHandling = NullValueHandling.Ignore)]
         public int FavoritingsCount { get; set; }
 
         [JsonProperty(PropertyName = "comment_count", NullValueHandling = NullValueHandling.Ignore)]
         public int CommentsCount { get; set; }
 
-        [JsonProperty(PropertyName = "attachments_uri")]
+        [JsonProperty(PropertyName = "attachments_uri", NullValueHandling = NullValueHandling.Ignore)]
         public string AttachmentUri { get; set; }
 
-        [JsonProperty(PropertyName = "original_content_size")]
+        [JsonProperty(PropertyName = "original_content_size", NullValueHandling = NullValueHandling.Ignore)]
         public long? OriginalContentSize { get; set; }
 
-        [JsonProperty(PropertyName = "created_with")]
+        [JsonProperty(PropertyName = "created_with", NullValueHandling = NullValueHandling.Ignore)]
         public Application CreatedWith { get; set; }
     }
 }

--- a/SoundCloud.API.Client/Internal/Objects/TrackCollection.cs
+++ b/SoundCloud.API.Client/Internal/Objects/TrackCollection.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using SoundCloud.API.Client.Objects;
+using System.Collections.Generic;
+
+namespace SoundCloud.API.Client.Internal.Objects
+{
+    internal class TrackCollection
+    {
+        [JsonProperty(PropertyName = "collection")]
+        public List<Track> Tracks { get; set; }
+    }
+}

--- a/SoundCloud.API.Client/Objects/SCExploreCategory.cs
+++ b/SoundCloud.API.Client/Objects/SCExploreCategory.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace SoundCloud.API.Client.Objects
+{
+    public class SCExploreCategory
+    {
+        public string Name { get; set; }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/SoundCloud.API.Client/Objects/SCTrack.cs
+++ b/SoundCloud.API.Client/Objects/SCTrack.cs
@@ -52,5 +52,10 @@ namespace SoundCloud.API.Client.Objects
         public SCEmbeddableBy EmbeddableBy { get; set; }
         public long? OriginalContentSize { get; set; }
         public SCApplication CreatedWith { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("{1} ({2}, {3})", User.UserName, Title, Id, PermalinkUrl);
+        }
     }
 }

--- a/SoundCloud.API.Client/SoundCloud.API.Client.csproj
+++ b/SoundCloud.API.Client/SoundCloud.API.Client.csproj
@@ -109,6 +109,8 @@
     <Compile Include="Internal\Objects\ActivityResult.cs" />
     <Compile Include="Internal\Objects\Application.cs" />
     <Compile Include="Internal\Objects\Auth\AccessToken.cs" />
+    <Compile Include="Internal\Objects\ChartTrack.cs" />
+    <Compile Include="Internal\Objects\ChartTrackList.cs" />
     <Compile Include="Internal\Objects\Comment.cs" />
     <Compile Include="Internal\Objects\Connection.cs" />
     <Compile Include="Internal\Objects\ExploreCategoryList.cs" />
@@ -162,6 +164,7 @@
     <Compile Include="SoundCloudApiException.cs" />
     <Compile Include="SoundCloudConnector.cs" />
     <Compile Include="Subresources\AuthApi.cs" />
+    <Compile Include="Subresources\ChartApi.cs" />
     <Compile Include="Subresources\CommentApi.cs" />
     <Compile Include="Subresources\ExploreApi.cs" />
     <Compile Include="Subresources\Factories\ISubresourceFactory.cs" />
@@ -176,6 +179,7 @@
     <Compile Include="Subresources\Helpers\ValidationHelper.cs" />
     <Compile Include="Subresources\IAppApi.cs" />
     <Compile Include="Subresources\IAuthApi.cs" />
+    <Compile Include="Subresources\IChartApi.cs" />
     <Compile Include="Subresources\ICommentApi.cs" />
     <Compile Include="Subresources\IExploreApi.cs" />
     <Compile Include="Subresources\IGroupApi.cs" />

--- a/SoundCloud.API.Client/SoundCloud.API.Client.csproj
+++ b/SoundCloud.API.Client/SoundCloud.API.Client.csproj
@@ -65,11 +65,13 @@
     <Compile Include="Internal\Converters\Auth\IAccessTokenConverter.cs" />
     <Compile Include="Internal\Converters\CommentConverter.cs" />
     <Compile Include="Internal\Converters\ConnectionConverter.cs" />
+    <Compile Include="Internal\Converters\ExploreCategoryConverter.cs" />
     <Compile Include="Internal\Converters\GroupConverter.cs" />
     <Compile Include="Internal\Converters\IActivityResultConverter.cs" />
     <Compile Include="Internal\Converters\IApplicationConverter.cs" />
     <Compile Include="Internal\Converters\ICommentConverter.cs" />
     <Compile Include="Internal\Converters\IConnectionConverter.cs" />
+    <Compile Include="Internal\Converters\IExploreCategoryConverter.cs" />
     <Compile Include="Internal\Converters\IGroupConverter.cs" />
     <Compile Include="Internal\Converters\Infrastructure\DateTimeConverter.cs" />
     <Compile Include="Internal\Converters\Infrastructure\IDateTimeConverter.cs" />
@@ -109,9 +111,12 @@
     <Compile Include="Internal\Objects\Auth\AccessToken.cs" />
     <Compile Include="Internal\Objects\Comment.cs" />
     <Compile Include="Internal\Objects\Connection.cs" />
+    <Compile Include="Internal\Objects\ExploreCategoryList.cs" />
+    <Compile Include="Internal\Objects\ExploreTrackList.cs" />
     <Compile Include="Internal\Objects\Group.cs" />
     <Compile Include="Internal\Objects\Playlist.cs" />
     <Compile Include="Internal\Objects\Track.cs" />
+    <Compile Include="Internal\Objects\TrackCollection.cs" />
     <Compile Include="Internal\Objects\UnsavedConnection.cs" />
     <Compile Include="Internal\Objects\User.cs" />
     <Compile Include="Internal\Objects\WebProfile.cs" />
@@ -131,6 +136,7 @@
     <Compile Include="Objects\SCApplication.cs" />
     <Compile Include="Objects\SCComment.cs" />
     <Compile Include="Objects\SCConnection.cs" />
+    <Compile Include="Objects\SCExploreCategory.cs" />
     <Compile Include="Objects\SCGroup.cs" />
     <Compile Include="Objects\SCOEmbed.cs" />
     <Compile Include="Objects\SCPlaylist.cs" />
@@ -157,6 +163,7 @@
     <Compile Include="SoundCloudConnector.cs" />
     <Compile Include="Subresources\AuthApi.cs" />
     <Compile Include="Subresources\CommentApi.cs" />
+    <Compile Include="Subresources\ExploreApi.cs" />
     <Compile Include="Subresources\Factories\ISubresourceFactory.cs" />
     <Compile Include="Subresources\Factories\SubresourceFactory.cs" />
     <Compile Include="Subresources\GroupApi.cs" />
@@ -170,6 +177,7 @@
     <Compile Include="Subresources\IAppApi.cs" />
     <Compile Include="Subresources\IAuthApi.cs" />
     <Compile Include="Subresources\ICommentApi.cs" />
+    <Compile Include="Subresources\IExploreApi.cs" />
     <Compile Include="Subresources\IGroupApi.cs" />
     <Compile Include="Subresources\IGroupsApi.cs" />
     <Compile Include="Subresources\IMeApi.cs" />

--- a/SoundCloud.API.Client/SoundCloud.API.Client.csproj
+++ b/SoundCloud.API.Client/SoundCloud.API.Client.csproj
@@ -30,9 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -209,7 +209,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/SoundCloud.API.Client/SoundCloudClient.cs
+++ b/SoundCloud.API.Client/SoundCloudClient.cs
@@ -20,6 +20,7 @@ namespace SoundCloud.API.Client
             Groups = subresourceFactory.CreateGroups();
             Resolve = subresourceFactory.CreateResolve();
             Explore = subresourceFactory.CreateExplore();
+            Chart = subresourceFactory.CreateChart();
             OEmbed = subresourceFactory.CreateOEmbed();
         }
 
@@ -66,6 +67,8 @@ namespace SoundCloud.API.Client
         public IResolveApi Resolve { get; private set; }
 
         public IExploreApi Explore { get; private set; }
+
+        public IChartApi Chart { get; private set; }
 
         public IOEmbed OEmbed { get; private set; }
     }

--- a/SoundCloud.API.Client/SoundCloudClient.cs
+++ b/SoundCloud.API.Client/SoundCloudClient.cs
@@ -19,6 +19,7 @@ namespace SoundCloud.API.Client
             Me = subresourceFactory.CreateMe();
             Groups = subresourceFactory.CreateGroups();
             Resolve = subresourceFactory.CreateResolve();
+            Explore = subresourceFactory.CreateExplore();
             OEmbed = subresourceFactory.CreateOEmbed();
         }
 
@@ -63,6 +64,9 @@ namespace SoundCloud.API.Client
         }
 
         public IResolveApi Resolve { get; private set; }
+
+        public IExploreApi Explore { get; private set; }
+
         public IOEmbed OEmbed { get; private set; }
     }
 }

--- a/SoundCloud.API.Client/Subresources/ChartApi.cs
+++ b/SoundCloud.API.Client/Subresources/ChartApi.cs
@@ -35,9 +35,10 @@ namespace SoundCloud.API.Client.Subresources
             parameters.Add("kind", "top");
 
             //Build genre paramter
-            var processed = (category == null || category.Name == "Popular+Music") ? "all-music" : new String(category.Name.Where(ch => Char.IsLetterOrDigit(ch)).ToArray()).ToLower();
-            var g = string.Format("soundcloud:genres:{0}", processed);
+            var processed = (category == null || category.Name == "Popular+Music") ? "all-music" : new String(System.Uri.UnescapeDataString(category.Name).Where(ch => Char.IsLetterOrDigit(ch)).ToArray()).ToLower();
+            var g = string.Format("soundcloud%3Agenres%3A{0}", processed);
             parameters.Add("genre", g);
+            parameters.Add("linked_partitioning", 1);
 
             var tracks = soundCloudRawClient.Request<ChartTrackList>(prefix, command, HttpMethod.Get, parameters: parameters.SetPagination(offset, limit), domain: Internal.Client.Helpers.Domain.ApiV2, responseType: string.Empty);
             return tracks.Tracks.Select(ct => trackConverter.Convert(ct.Track)).ToArray();

--- a/SoundCloud.API.Client/Subresources/ChartApi.cs
+++ b/SoundCloud.API.Client/Subresources/ChartApi.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SoundCloud.API.Client.Internal.Client;
+using SoundCloud.API.Client.Internal.Converters;
+using SoundCloud.API.Client.Internal.Infrastructure.Objects;
+using SoundCloud.API.Client.Internal.Objects;
+using SoundCloud.API.Client.Internal.Validation;
+using SoundCloud.API.Client.Objects;
+using SoundCloud.API.Client.Subresources.Helpers;
+using System.Text.RegularExpressions;
+
+namespace SoundCloud.API.Client.Subresources
+{
+    class ChartApi : IChartApi
+    {
+        private readonly ISoundCloudRawClient soundCloudRawClient;
+        private readonly IPaginationValidator paginationValidator;
+        private readonly ITrackConverter trackConverter;
+        private const string prefix = "";
+        private const string command = "charts";
+
+        internal ChartApi(ISoundCloudRawClient soundCloudRawClient, IPaginationValidator paginationValidator, ITrackConverter trackConverter)
+        {
+            this.soundCloudRawClient = soundCloudRawClient;
+            this.paginationValidator = paginationValidator;
+            this.trackConverter = trackConverter;
+        }
+
+        public SCTrack[] GetTracks(SCExploreCategory category, int offset = 0, int limit = 10)
+        {
+            paginationValidator.Validate(offset, limit);
+
+            var parameters = new Dictionary<string, object>();
+            parameters.Add("kind", "top");
+
+            //Build genre paramter
+            var processed = (category == null || category.Name == "Popular+Music") ? "all-music" : new String(category.Name.Where(ch => Char.IsLetterOrDigit(ch)).ToArray()).ToLower();
+            var g = string.Format("soundcloud:genres:{0}", processed);
+            parameters.Add("genre", g);
+
+            var tracks = soundCloudRawClient.Request<ChartTrackList>(prefix, command, HttpMethod.Get, parameters: parameters.SetPagination(offset, limit), domain: Internal.Client.Helpers.Domain.ApiV2, responseType: string.Empty);
+            return tracks.Tracks.Select(ct => trackConverter.Convert(ct.Track)).ToArray();
+        }
+    }
+}

--- a/SoundCloud.API.Client/Subresources/ExploreApi.cs
+++ b/SoundCloud.API.Client/Subresources/ExploreApi.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SoundCloud.API.Client.Internal.Client;
+using SoundCloud.API.Client.Internal.Converters;
+using SoundCloud.API.Client.Internal.Infrastructure.Objects;
+using SoundCloud.API.Client.Internal.Objects;
+using SoundCloud.API.Client.Internal.Validation;
+using SoundCloud.API.Client.Objects;
+using SoundCloud.API.Client.Subresources.Helpers;
+
+namespace SoundCloud.API.Client.Subresources
+{
+    public class ExploreApi : IExploreApi
+    {
+        private readonly ISoundCloudRawClient soundCloudRawClient;
+        private readonly IPaginationValidator paginationValidator;
+        private readonly IExploreCategoryConverter exploreCategoryConverter;
+        private readonly ITrackConverter trackConverter;
+        private const string prefix = "explore";
+        private const string categoryCommand = "categories";
+
+        internal ExploreApi(ISoundCloudRawClient soundCloudRawClient, IPaginationValidator paginationValidator, IExploreCategoryConverter exploreCategoryConverter, ITrackConverter trackConverter)
+        {
+            this.soundCloudRawClient = soundCloudRawClient;
+            this.paginationValidator = paginationValidator;
+            this.exploreCategoryConverter = exploreCategoryConverter;
+            this.trackConverter = trackConverter;
+        }
+        public SCExploreCategory[] GetExploreCategories()
+        {
+            var categories = soundCloudRawClient.Request<ExploreCategoryList>(prefix, categoryCommand, HttpMethod.Get, domain: Internal.Client.Helpers.Domain.ApiV2, responseType: string.Empty);
+            return exploreCategoryConverter.Convert(categories);
+        }
+
+        public SCTrack[] GetTracks(SCExploreCategory category, int offset = 0, int limit = 10)
+        {
+            paginationValidator.Validate(offset, limit);
+
+            var parameters = new Dictionary<string, object>();
+
+            var tracks = soundCloudRawClient.Request<ExploreTrackList>(prefix, category.Name, HttpMethod.Get, parameters: parameters.SetPagination(offset, limit), domain: Internal.Client.Helpers.Domain.ApiV2, responseType: string.Empty);
+            return tracks.Tracks.Select(trackConverter.Convert).ToArray();
+        }
+    }
+}

--- a/SoundCloud.API.Client/Subresources/Factories/ISubresourceFactory.cs
+++ b/SoundCloud.API.Client/Subresources/Factories/ISubresourceFactory.cs
@@ -14,6 +14,7 @@
         IAppApi CreateApp(string applicationId);
         IResolveApi CreateResolve();
         IExploreApi CreateExplore();
+        IChartApi CreateChart();
         IOEmbed CreateOEmbed();
     }
 }

--- a/SoundCloud.API.Client/Subresources/Factories/ISubresourceFactory.cs
+++ b/SoundCloud.API.Client/Subresources/Factories/ISubresourceFactory.cs
@@ -13,6 +13,7 @@
         IGroupsApi CreateGroups();
         IAppApi CreateApp(string applicationId);
         IResolveApi CreateResolve();
+        IExploreApi CreateExplore();
         IOEmbed CreateOEmbed();
     }
 }

--- a/SoundCloud.API.Client/Subresources/Factories/SubresourceFactory.cs
+++ b/SoundCloud.API.Client/Subresources/Factories/SubresourceFactory.cs
@@ -108,6 +108,11 @@ namespace SoundCloud.API.Client.Subresources.Factories
             return new ExploreApi(soundCloudRawClient, paginationValidator, exploreCategoryConverter, trackConverter);
         }
 
+        public IChartApi CreateChart()
+        {
+            return new ChartApi(soundCloudRawClient, paginationValidator, trackConverter);
+        }
+
         public IOEmbed CreateOEmbed()
         {
             return new OEmbed(soundCloudRawClient);

--- a/SoundCloud.API.Client/Subresources/Factories/SubresourceFactory.cs
+++ b/SoundCloud.API.Client/Subresources/Factories/SubresourceFactory.cs
@@ -17,6 +17,7 @@ namespace SoundCloud.API.Client.Subresources.Factories
         private readonly IConnectionConverter connectionConverter;
         private readonly IActivityResultConverter activityResultConverter;
         private readonly IApplicationConverter applicationConverter;
+        private readonly IExploreCategoryConverter exploreCategoryConverter;
 
         public SubresourceFactory(
             ISoundCloudRawClient soundCloudRawClient,
@@ -29,7 +30,8 @@ namespace SoundCloud.API.Client.Subresources.Factories
             IWebProfileConverter webProfileConverter,
             IConnectionConverter connectionConverter,
             IActivityResultConverter activityResultConverter,
-            IApplicationConverter applicationConverter)
+            IApplicationConverter applicationConverter,
+            IExploreCategoryConverter exploreCategoryConverter)
         {
             this.soundCloudRawClient = soundCloudRawClient;
             this.paginationValidator = paginationValidator;
@@ -42,6 +44,7 @@ namespace SoundCloud.API.Client.Subresources.Factories
             this.connectionConverter = connectionConverter;
             this.activityResultConverter = activityResultConverter;
             this.applicationConverter = applicationConverter;
+            this.exploreCategoryConverter = exploreCategoryConverter;
         }
 
         public IUserApi CreateUser(string userId)
@@ -98,6 +101,11 @@ namespace SoundCloud.API.Client.Subresources.Factories
         public IResolveApi CreateResolve()
         {
             return new ResolveApi(soundCloudRawClient, groupConverter, userConverter, trackConverter, playlistConverter);
+        }
+
+        public IExploreApi CreateExplore()
+        {
+            return new ExploreApi(soundCloudRawClient, paginationValidator, exploreCategoryConverter, trackConverter);
         }
 
         public IOEmbed CreateOEmbed()

--- a/SoundCloud.API.Client/Subresources/Helpers/TracksSearcher.cs
+++ b/SoundCloud.API.Client/Subresources/Helpers/TracksSearcher.cs
@@ -19,7 +19,7 @@ namespace SoundCloud.API.Client.Subresources.Helpers
         private readonly Func<Dictionary<string, object>, SCTrack[]> search;
         private readonly Dictionary<string, object> searchParameters;
 
-        internal TracksSearcher(SCFilter filter, IPaginationValidator paginationValidator, Func<Dictionary<string, object>, SCTrack[]> search)
+        internal TracksSearcher(SCFilter filter, bool useNewApi, IPaginationValidator paginationValidator, Func<Dictionary<string, object>, SCTrack[]> search)
         {
             if (filter == SCFilter.Private)
             {

--- a/SoundCloud.API.Client/Subresources/IChartApi.cs
+++ b/SoundCloud.API.Client/Subresources/IChartApi.cs
@@ -1,0 +1,9 @@
+﻿using SoundCloud.API.Client.Objects;
+
+namespace SoundCloud.API.Client.Subresources
+{
+    public interface IChartApi
+    {
+        SCTrack[] GetTracks(SCExploreCategory category, int offset = 0, int limit = 20);
+    }
+}

--- a/SoundCloud.API.Client/Subresources/IExploreApi.cs
+++ b/SoundCloud.API.Client/Subresources/IExploreApi.cs
@@ -1,0 +1,10 @@
+﻿using SoundCloud.API.Client.Objects;
+
+namespace SoundCloud.API.Client.Subresources
+{
+    public interface IExploreApi
+    {
+        SCExploreCategory[] GetExploreCategories();
+        SCTrack[] GetTracks(SCExploreCategory category, int offset = 0, int limit = 10);
+    }
+}

--- a/SoundCloud.API.Client/Subresources/ITracksApi.cs
+++ b/SoundCloud.API.Client/Subresources/ITracksApi.cs
@@ -8,6 +8,6 @@ namespace SoundCloud.API.Client.Subresources
     public interface ITracksApi
     {
         SCTrack UploadTrack(Stream trackFileStream, string title, string description, SCSharing sharing, Stream artworkFileStream = null);
-        ITracksSearcher BeginSearch(SCFilter filter);
+        ITracksSearcher BeginSearch(SCFilter filter, bool useNewApi = true);
     }
 }

--- a/SoundCloud.API.Client/UnauthorizedSoundCloudClient.cs
+++ b/SoundCloud.API.Client/UnauthorizedSoundCloudClient.cs
@@ -18,6 +18,7 @@ namespace SoundCloud.API.Client
             Groups = subresourceFactory.CreateGroups();
             Resolve = subresourceFactory.CreateResolve();
             Explore = subresourceFactory.CreateExplore();
+            Chart = subresourceFactory.CreateChart();
             OEmbed = subresourceFactory.CreateOEmbed();
         }
 
@@ -62,6 +63,8 @@ namespace SoundCloud.API.Client
         public IResolveApi Resolve { get; private set; }
 
         public IExploreApi Explore { get; private set; }
+
+        public IChartApi Chart { get; private set; }
 
         public IOEmbed OEmbed { get; private set; }
     }

--- a/SoundCloud.API.Client/UnauthorizedSoundCloudClient.cs
+++ b/SoundCloud.API.Client/UnauthorizedSoundCloudClient.cs
@@ -17,6 +17,7 @@ namespace SoundCloud.API.Client
             Me = subresourceFactory.CreateMe();
             Groups = subresourceFactory.CreateGroups();
             Resolve = subresourceFactory.CreateResolve();
+            Explore = subresourceFactory.CreateExplore();
             OEmbed = subresourceFactory.CreateOEmbed();
         }
 
@@ -59,6 +60,9 @@ namespace SoundCloud.API.Client
         }
 
         public IResolveApi Resolve { get; private set; }
+
+        public IExploreApi Explore { get; private set; }
+
         public IOEmbed OEmbed { get; private set; }
     }
 }

--- a/SoundCloud.API.Client/packages.config
+++ b/SoundCloud.API.Client/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi,

I added support for the API-V2 endpoint, specifically the Explore and Charts api.
I also added null value handling to the JSON parser, and ignored new line characters in tag parsing, since it was broken for me.

Cheers,
Patrick
